### PR TITLE
add 'paidAt<From|To>' filter for orders request

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -207,6 +207,8 @@ type OrdersFilter struct {
 	Sites                          []string          `url:"sites,omitempty,brackets"`
 	CreatedAtFrom                  string            `url:"createdAtFrom,omitempty"`
 	CreatedAtTo                    string            `url:"createdAtTo,omitempty"`
+	PaidAtFrom                     string            `url:"paidAtFrom, omitempty"`
+	PaidAtTo                       string            `url:"paidAtTo, omitempty"`
 	FullPaidAtFrom                 string            `url:"fullPaidAtFrom,omitempty"`
 	FullPaidAtTo                   string            `url:"fullPaidAtTo,omitempty"`
 	DeliveryDateFrom               string            `url:"deliveryDateFrom,omitempty"`


### PR DESCRIPTION
Added a fields `OrdersFilter.PaidAtFrom` and `OrdersFilter.PaidAtTo` according to the filters of the `/api/v5/orders` endpoint.