### PR TITLE
Support string or numeric store ordering

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -2592,6 +2592,88 @@ func TestClient_OrdersOrders(t *testing.T) {
 	}
 }
 
+func TestClient_OrdersActualDTOFields(t *testing.T) {
+	c := client()
+
+	defer gock.Off()
+
+	gock.New(crmURL).
+		Get("/orders").
+		MatchParam("filter[segment]", "vip").
+		MatchParam("filter[customerType]", "customer").
+		MatchParam("filter[productSearchType]", "name").
+		MatchParam("filter[statusHistorySequence][]", "new").
+		MatchParam("filter[deliveryStates][]", "processing").
+		MatchParam("filter[deliveryExternalId]", "delivery-1").
+		MatchParam("filter[companyName]", "RetailCRM").
+		MatchParam("filter[deliveryAddressNotes]", "front door").
+		MatchParam("filter[productGroups][]", "12").
+		MatchParam("filter[receiptOrderStatus]", "done").
+		MatchParam("filter[mgChannels][]", "7").
+		MatchParam("filter[tasksCounts]", "2").
+		MatchParam("filter[tags][]", "priority").
+		MatchParam("filter[attachedTags][]", "new-client").
+		Reply(http.StatusOK).
+		BodyString(`{
+			"success": true,
+			"orders": [{
+				"id": 1,
+				"company": {
+					"averageSumm": 1000,
+					"avgMarginSumm": 200,
+					"costSumm": 300,
+					"marginSumm": 400,
+					"ordersCount": 5,
+					"totalSumm": 6000
+				},
+				"items": [{
+					"offer": {
+						"displayName": "SKU display name"
+					}
+				}],
+				"links": [{
+					"order": {
+						"id": 2,
+						"number": "1002",
+						"externalId": "external-2"
+					}
+				}]
+			}]
+		}`)
+
+	data, status, err := c.Orders(OrdersRequest{
+		Filter: OrdersFilter{
+			Segment:               "vip",
+			CustomerType:          "customer",
+			ProductSearchType:     "name",
+			StatusHistorySequence: []string{"new"},
+			DeliveryStates:        []string{"processing"},
+			DeliveryExternalID:    "delivery-1",
+			CompanyName:           "RetailCRM",
+			DeliveryAddressNotes:  "front door",
+			ProductGroups:         []int{12},
+			ReceiptOrderStatus:    "done",
+			MGChannels:            []int{7},
+			TasksCounts:           2,
+			Tags:                  []string{"priority"},
+			AttachedTags:          []string{"new-client"},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.True(t, data.Success)
+	assert.Len(t, data.Orders, 1)
+	assert.Equal(t, float32(1000), data.Orders[0].Company.AverageSumm)
+	assert.Equal(t, float32(200), data.Orders[0].Company.AvgMarginSumm)
+	assert.Equal(t, float32(300), data.Orders[0].Company.CostSumm)
+	assert.Equal(t, float32(400), data.Orders[0].Company.MarginSumm)
+	assert.Equal(t, 5, data.Orders[0].Company.OrdersCount)
+	assert.Equal(t, float32(6000), data.Orders[0].Company.TotalSumm)
+	assert.Equal(t, "SKU display name", data.Orders[0].Items[0].Offer.DisplayName)
+	assert.Equal(t, "external-2", data.Orders[0].Links[0].Order.ExternalID)
+}
+
 func TestClient_OrdersOrders_Fail(t *testing.T) {
 	c := client()
 
@@ -3190,7 +3272,26 @@ func TestClient_OrderChange(t *testing.T) {
 		Get(fmt.Sprintf("/orders/%s", f.ExternalID)).
 		MatchParam("by", ByExternalID).
 		Reply(200).
-		BodyString(`{"success": true}`)
+		BodyString(`{
+			"success": true,
+			"order": {
+				"id": 1,
+				"company": {
+					"averageSumm": 1000,
+					"ordersCount": 5
+				},
+				"items": [{
+					"offer": {
+						"displayName": "SKU display name"
+					}
+				}],
+				"links": [{
+					"order": {
+						"externalId": "external-2"
+					}
+				}]
+			}
+		}`)
 
 	data, status, err := c.Order(f.ExternalID, ByExternalID, "")
 	if err != nil {
@@ -3204,6 +3305,11 @@ func TestClient_OrderChange(t *testing.T) {
 	if data.Success != true {
 		t.Errorf("%v", err)
 	}
+
+	assert.Equal(t, float32(1000), data.Order.Company.AverageSumm)
+	assert.Equal(t, 5, data.Order.Company.OrdersCount)
+	assert.Equal(t, "SKU display name", data.Order.Items[0].Offer.DisplayName)
+	assert.Equal(t, "external-2", data.Order.Links[0].Order.ExternalID)
 }
 
 func TestClient_OrderChange_Fail(t *testing.T) {
@@ -4726,7 +4832,19 @@ func TestClient_ProductStatuses(t *testing.T) {
 	gock.New(crmURL).
 		Get("/reference/product-statuses").
 		Reply(200).
-		BodyString(`{"success": true}`)
+		BodyString(`{
+			"success": true,
+			"productStatuses": [{
+				"code": "available",
+				"ordering": 10,
+				"active": true,
+				"createdAt": "2026-05-11 10:00:00",
+				"orderStatusByProductStatus": "complete",
+				"orderStatusForProductStatus": "assembled",
+				"cancelStatus": false,
+				"name": "Available"
+			}]
+		}`)
 
 	data, st, err := c.ProductStatuses()
 	if err != nil {
@@ -4740,6 +4858,16 @@ func TestClient_ProductStatuses(t *testing.T) {
 	if data.Success != true {
 		t.Errorf("%v", err)
 	}
+
+	assert.Len(t, data.ProductStatuses, 1)
+	assert.Equal(t, "available", data.ProductStatuses[0].Code)
+	assert.Equal(t, 10, data.ProductStatuses[0].Ordering)
+	assert.True(t, data.ProductStatuses[0].Active)
+	assert.Equal(t, "2026-05-11 10:00:00", data.ProductStatuses[0].CreatedAt)
+	assert.Equal(t, "complete", data.ProductStatuses[0].OrderStatusByProductStatus)
+	assert.Equal(t, "assembled", data.ProductStatuses[0].OrderStatusForProductStatus)
+	assert.False(t, data.ProductStatuses[0].CancelStatus)
+	assert.Equal(t, "Available", data.ProductStatuses[0].Name)
 }
 
 func TestClient_Statuses(t *testing.T) {

--- a/filters.go
+++ b/filters.go
@@ -152,6 +152,8 @@ type OrdersFilter struct {
 	Customer                       string            `url:"customer,omitempty"`
 	CustomerID                     string            `url:"customerId,omitempty"`
 	CustomerExternalID             string            `url:"customerExternalId,omitempty"`
+	Segment                        string            `url:"segment,omitempty"`
+	CustomerType                   string            `url:"customerType,omitempty"`
 	Countries                      []string          `url:"countries,omitempty,brackets"`
 	City                           string            `url:"city,omitempty"`
 	Region                         string            `url:"region,omitempty"`
@@ -165,6 +167,7 @@ type OrdersFilter struct {
 	MinPrice                       string            `url:"minPrice,omitempty"`
 	MaxPrice                       string            `url:"maxPrice,omitempty"`
 	Product                        string            `url:"product,omitempty"`
+	ProductSearchType              string            `url:"productSearchType,omitempty"`
 	Vip                            int               `url:"vip,omitempty"`
 	Bad                            int               `url:"bad,omitempty"`
 	Attachments                    int               `url:"attachments,omitempty"`
@@ -176,6 +179,7 @@ type OrdersFilter struct {
 	ReceiptFiscalDocumentAttribute int               `url:"receiptFiscalDocumentAttribute,omitempty"`
 	ReceiptStatus                  int               `url:"receiptStatus,omitempty"`
 	ReceiptOperation               int               `url:"receiptOperation,omitempty"`
+	ReceiptOrderStatus             string            `url:"receiptOrderStatus,omitempty"`
 	MinDeliveryCost                string            `url:"minDeliveryCost,omitempty"`
 	MaxDeliveryCost                string            `url:"maxDeliveryCost,omitempty"`
 	MinDeliveryNetCost             string            `url:"minDeliveryNetCost,omitempty"`
@@ -189,6 +193,9 @@ type OrdersFilter struct {
 	MinCostSumm                    string            `url:"minCostSumm,omitempty"`
 	MaxCostSumm                    string            `url:"maxCostSumm,omitempty"`
 	TrackNumber                    string            `url:"trackNumber,omitempty"`
+	DeliveryExternalID             string            `url:"deliveryExternalId,omitempty"`
+	CompanyName                    string            `url:"companyName,omitempty"`
+	DeliveryAddressNotes           string            `url:"deliveryAddressNotes,omitempty"`
 	ContragentName                 string            `url:"contragentName,omitempty"`
 	ContragentInn                  string            `url:"contragentInn,omitempty"`
 	ContragentKpp                  string            `url:"contragentKpp,omitempty"`
@@ -199,14 +206,20 @@ type OrdersFilter struct {
 	OrderTypes                     []string          `url:"orderTypes,omitempty,brackets"`
 	PaymentStatuses                []string          `url:"paymentStatuses,omitempty,brackets"`
 	PaymentTypes                   []string          `url:"paymentTypes,omitempty,brackets"`
+	DeliveryStates                 []string          `url:"deliveryStates,omitempty,brackets"`
 	DeliveryTypes                  []string          `url:"deliveryTypes,omitempty,brackets"`
 	DeliveryServices               []string          `url:"deliveryServices,omitempty,brackets"`
 	OrderMethods                   []string          `url:"orderMethods,omitempty,brackets"`
+	ProductGroups                  []int             `url:"productGroups,omitempty,brackets"`
 	ShipmentStores                 []string          `url:"shipmentStores,omitempty,brackets"`
 	Couriers                       []string          `url:"couriers,omitempty,brackets"`
 	Managers                       []string          `url:"managers,omitempty,brackets"`
 	ManagerGroups                  []string          `url:"managerGroups,omitempty,brackets"`
+	MGChannels                     []int             `url:"mgChannels,omitempty,brackets"`
 	Sites                          []string          `url:"sites,omitempty,brackets"`
+	TasksCounts                    int               `url:"tasksCounts,omitempty"`
+	Tags                           []string          `url:"tags,omitempty,brackets"`
+	AttachedTags                   []string          `url:"attachedTags,omitempty,brackets"`
 	CreatedAtFrom                  string            `url:"createdAtFrom,omitempty"`
 	CreatedAtTo                    string            `url:"createdAtTo,omitempty"`
 	PaidAtFrom                     string            `url:"paidAtFrom,omitempty"`
@@ -230,6 +243,7 @@ type OrdersFilter struct {
 	ShipmentDateFrom               string            `url:"shipmentDateFrom,omitempty"`
 	ShipmentDateTo                 string            `url:"shipmentDateTo,omitempty"`
 	ExtendedStatus                 []string          `url:"extendedStatus,omitempty,brackets"`
+	StatusHistorySequence          []string          `url:"statusHistorySequence,omitempty,brackets"`
 	SourceName                     string            `url:"sourceName,omitempty"`
 	MediumName                     string            `url:"mediumName,omitempty"`
 	CampaignName                   string            `url:"campaignName,omitempty"`

--- a/marshaling.go
+++ b/marshaling.go
@@ -1,6 +1,7 @@
 package retailcrm
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -8,6 +9,32 @@ import (
 
 func (t Tag) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Name)
+}
+
+func (v *StringOrNumber) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*v = ""
+		return nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return err
+	}
+
+	switch value := value.(type) {
+	case string:
+		*v = StringOrNumber(value)
+	case json.Number:
+		*v = StringOrNumber(value.String())
+	default:
+		return fmt.Errorf("string or number: expected string or number, got %T", value)
+	}
+
+	return nil
 }
 
 func (a *APIErrorsList) UnmarshalJSON(data []byte) error {

--- a/marshaling_test.go
+++ b/marshaling_test.go
@@ -26,6 +26,40 @@ func TestTag_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestStringOrNumber_UnmarshalJSON(t *testing.T) {
+	var value StringOrNumber
+
+	require.NoError(t, json.Unmarshal([]byte(`"10"`), &value))
+	assert.Equal(t, StringOrNumber("10"), value)
+
+	require.NoError(t, json.Unmarshal([]byte(`20`), &value))
+	assert.Equal(t, StringOrNumber("20"), value)
+
+	require.NoError(t, json.Unmarshal([]byte(`null`), &value))
+	assert.Empty(t, value)
+
+	require.Error(t, json.Unmarshal([]byte(`true`), &value))
+}
+
+func TestStringOrNumber_MarshalJSON(t *testing.T) {
+	store := Store{Code: "main", Ordering: "10"}
+
+	data, err := json.Marshal(store)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"code":"main","ordering":"10"}`, string(data))
+}
+
+func TestStoreOrdering_UnmarshalStringOrNumber(t *testing.T) {
+	var fromString Store
+	require.NoError(t, json.Unmarshal([]byte(`{"ordering":"10"}`), &fromString))
+	assert.Equal(t, StringOrNumber("10"), fromString.Ordering)
+
+	var fromNumber Store
+	require.NoError(t, json.Unmarshal([]byte(`{"ordering":20}`), &fromNumber))
+	assert.Equal(t, StringOrNumber("20"), fromNumber.Ordering)
+}
+
 func TestAPIErrorsList_UnmarshalJSON(t *testing.T) {
 	var list APIErrorsList
 

--- a/response.go
+++ b/response.go
@@ -327,8 +327,8 @@ type PriceTypesResponse struct {
 
 // ProductStatusesResponse type.
 type ProductStatusesResponse struct {
-	Success         bool                     `json:"success"`
-	ProductStatuses map[string]ProductStatus `json:"productStatuses,omitempty"`
+	Success         bool            `json:"success"`
+	ProductStatuses []ProductStatus `json:"productStatuses,omitempty"`
 }
 
 // StatusesResponse type.

--- a/types.go
+++ b/types.go
@@ -310,18 +310,24 @@ type CartCustomer struct {
 }
 
 type Company struct {
-	ID           int              `json:"id,omitempty"`
-	IsMain       bool             `json:"isMain,omitempty"`
-	ExternalID   string           `json:"externalId,omitempty"`
-	Customer     *Customer        `json:"customer,omitempty"`
-	Active       bool             `json:"active,omitempty"`
-	Name         string           `json:"name,omitempty"`
-	Brand        string           `json:"brand,omitempty"`
-	Site         string           `json:"site,omitempty"`
-	CreatedAt    string           `json:"createdAt,omitempty"`
-	Contragent   *Contragent      `json:"contragent,omitempty"`
-	Address      *IdentifiersPair `json:"address,omitempty"`
-	CustomFields CustomFieldMap   `json:"customFields,omitempty"`
+	ID            int              `json:"id,omitempty"`
+	IsMain        bool             `json:"isMain,omitempty"`
+	ExternalID    string           `json:"externalId,omitempty"`
+	Customer      *Customer        `json:"customer,omitempty"`
+	Active        bool             `json:"active,omitempty"`
+	Name          string           `json:"name,omitempty"`
+	Brand         string           `json:"brand,omitempty"`
+	Site          string           `json:"site,omitempty"`
+	CreatedAt     string           `json:"createdAt,omitempty"`
+	Contragent    *Contragent      `json:"contragent,omitempty"`
+	Address       *IdentifiersPair `json:"address,omitempty"`
+	CustomFields  CustomFieldMap   `json:"customFields,omitempty"`
+	AvgMarginSumm float32          `json:"avgMarginSumm,omitempty"`
+	MarginSumm    float32          `json:"marginSumm,omitempty"`
+	TotalSumm     float32          `json:"totalSumm,omitempty"`
+	AverageSumm   float32          `json:"averageSumm,omitempty"`
+	OrdersCount   int              `json:"ordersCount,omitempty"`
+	CostSumm      float32          `json:"costSumm,omitempty"`
 }
 
 // CorporateCustomerNote type.
@@ -455,7 +461,7 @@ type Order struct {
 // LinkedOrder type.
 type LinkedOrder struct {
 	Number     string `json:"number,omitempty"`
-	ExternalID string `json:"externalID,omitempty"`
+	ExternalID string `json:"externalId,omitempty"`
 	ID         int    `json:"id,omitempty"`
 }
 
@@ -970,6 +976,7 @@ type Offer struct {
 	ID            int          `json:"id,omitempty"`
 	ExternalID    string       `json:"externalId,omitempty"`
 	Name          string       `json:"name,omitempty"`
+	DisplayName   string       `json:"displayName,omitempty"`
 	XMLID         string       `json:"xmlId,omitempty"`
 	Site          string       `json:"site,omitempty"`
 	Article       string       `json:"article,omitempty"`

--- a/types.go
+++ b/types.go
@@ -76,6 +76,9 @@ type Point struct {
 // GeoID type. Can be empty string.
 type GeoID json.Number
 
+// StringOrNumber stores API fields that are documented as strings, but may be returned as JSON numbers.
+type StringOrNumber string
+
 // GeoHierarchyRow type.
 type GeoHierarchyRow struct {
 	Country  string `json:"country,omitempty"`
@@ -1450,7 +1453,7 @@ type Store struct {
 	Type          string         `json:"type,omitempty"`
 	InventoryType string         `json:"inventoryType,omitempty"`
 	Active        bool           `json:"active,omitempty"`
-	Ordering      int            `json:"ordering,omitempty"`
+	Ordering      StringOrNumber `json:"ordering,omitempty"`
 	Phone         *Phone         `json:"phone,omitempty"`
 	Address       *Address       `json:"address,omitempty"`
 	Contact       string         `json:"contact,omitempty"`


### PR DESCRIPTION
Store.Ordering now uses StringOrNumber instead of int. The custom UnmarshalJSON accepts both JSON strings and JSON numbers, keeps the value as its decimal string representation, and treats null as the empty value. Default JSON marshaling for the string alias keeps outgoing Store payloads encoded as strings.

Backward compatibility risk: Store.Ordering is a public DTO field, so code that assigns int values, performs numeric operations, compares against int, or expects outgoing ordering to be encoded as a JSON number must be adapted. Ignoring this incompatibility can cause compile errors for library users and a payload shape change for write requests.