### PR TITLE
fix: update IntegrationModuleEdit DTOs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -6861,6 +6861,12 @@ func TestClient_IntegrationModule(t *testing.T) {
 		t.Errorf("%v", err)
 	}
 
+	assert.Equal(t, 38, m.Info.DeliveryTypeInfo.ID)
+	assert.Equal(t, "sdek-v-2-podkliuchenie-1", m.Info.DeliveryTypeInfo.Code)
+	require.NotNil(t, m.Info.BillingInfo)
+	require.NotNil(t, m.Info.BillingInfo.Currency)
+	assert.Equal(t, "RUB", m.Info.BillingInfo.Currency.Code)
+
 	gock.New(crmURL).
 		Get(fmt.Sprintf("/integration-modules/%s", code)).
 		Reply(200).
@@ -6878,6 +6884,42 @@ func TestClient_IntegrationModule(t *testing.T) {
 	if g.Success != true {
 		t.Errorf("%v", err)
 	}
+}
+
+func TestClient_IntegrationModule_InfoArray(t *testing.T) {
+	c := client()
+
+	code := RandomString(8)
+
+	defer gock.Off()
+
+	integrationModule := IntegrationModule{
+		Code:            code,
+		IntegrationCode: code,
+	}
+
+	jsonData := fmt.Sprintf(
+		`{"code":"%s","integrationCode":"%s"}`,
+		code,
+		code,
+	)
+
+	pr := url.Values{
+		"integrationModule": {jsonData},
+	}
+
+	gock.New(crmURL).
+		Post(fmt.Sprintf("/integration-modules/%s/edit", integrationModule.Code)).
+		MatchType("url").
+		BodyString(pr.Encode()).
+		Reply(200).
+		BodyString(`{"success": true, "info": []}`)
+
+	m, status, err := c.IntegrationModuleEdit(integrationModule)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.True(t, m.Success)
+	assert.Equal(t, ResponseInfo{}, m.Info)
 }
 
 func TestClient_IntegrationModule_Fail(t *testing.T) {

--- a/marshaling.go
+++ b/marshaling.go
@@ -11,6 +11,216 @@ func (t Tag) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Name)
 }
 
+func (a *AdditionalCode) UnmarshalJSON(data []byte) error {
+	var response struct {
+		Code   string          `json:"code"`
+		UserID json.RawMessage `json:"userId"`
+	}
+
+	if err := json.Unmarshal(data, &response); err != nil {
+		return err
+	}
+
+	a.Code = response.Code
+	a.UserID = ""
+
+	userID := bytes.TrimSpace(response.UserID)
+	if len(userID) == 0 || bytes.Equal(userID, []byte("null")) {
+		return nil
+	}
+
+	if userID[0] == '"' {
+		return json.Unmarshal(userID, &a.UserID)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(userID))
+	decoder.UseNumber()
+
+	var number json.Number
+	if err := decoder.Decode(&number); err != nil {
+		return err
+	}
+
+	if _, err := number.Int64(); err != nil {
+		return err
+	}
+
+	a.UserID = number.String()
+
+	return nil
+}
+
+func (f DeliveryDataField) MarshalJSON() ([]byte, error) {
+	choices := any(nil)
+	if len(f.ChoiceList) > 0 {
+		choices = f.ChoiceList
+	} else if len(f.Choices) > 0 {
+		choices = f.Choices
+	}
+
+	return json.Marshal(struct {
+		Code            string `json:"code,omitempty"`
+		Label           string `json:"label,omitempty"`
+		Hint            string `json:"hint,omitempty"`
+		Type            string `json:"type,omitempty"`
+		AutocompleteURL string `json:"autocompleteUrl,omitempty"`
+		Multiple        bool   `json:"multiple,omitempty"`
+		Choices         any    `json:"choices,omitempty"`
+		Visible         bool   `json:"visible,omitempty"`
+		Required        bool   `json:"required,omitempty"`
+		AffectsCost     bool   `json:"affectsCost,omitempty"`
+		Editable        bool   `json:"editable,omitempty"`
+	}{
+		Code:            f.Code,
+		Label:           f.Label,
+		Hint:            f.Hint,
+		Type:            f.Type,
+		AutocompleteURL: f.AutocompleteURL,
+		Multiple:        f.Multiple,
+		Choices:         choices,
+		Visible:         f.Visible,
+		Required:        f.Required,
+		AffectsCost:     f.AffectsCost,
+		Editable:        f.Editable,
+	})
+}
+
+func (f *DeliveryDataField) UnmarshalJSON(data []byte) error {
+	var response struct {
+		Code            string          `json:"code"`
+		Label           string          `json:"label"`
+		Hint            string          `json:"hint"`
+		Type            string          `json:"type"`
+		AutocompleteURL string          `json:"autocompleteUrl"`
+		Multiple        bool            `json:"multiple"`
+		Choices         json.RawMessage `json:"choices"`
+		Visible         bool            `json:"visible"`
+		Required        bool            `json:"required"`
+		AffectsCost     bool            `json:"affectsCost"`
+		Editable        bool            `json:"editable"`
+	}
+
+	if err := json.Unmarshal(data, &response); err != nil {
+		return err
+	}
+
+	f.Code = response.Code
+	f.Label = response.Label
+	f.Hint = response.Hint
+	f.Type = response.Type
+	f.AutocompleteURL = response.AutocompleteURL
+	f.Multiple = response.Multiple
+	f.Choices = nil
+	f.ChoiceList = nil
+	f.Visible = response.Visible
+	f.Required = response.Required
+	f.AffectsCost = response.AffectsCost
+	f.Editable = response.Editable
+
+	choices := bytes.TrimSpace(response.Choices)
+	if len(choices) == 0 || bytes.Equal(choices, []byte("null")) {
+		return nil
+	}
+
+	var choiceList []DeliveryDataFieldChoice
+	if err := json.Unmarshal(choices, &choiceList); err == nil {
+		f.ChoiceList = choiceList
+		f.Choices = make([]string, 0, len(choiceList))
+		for _, choice := range choiceList {
+			f.Choices = append(f.Choices, choice.Value)
+		}
+
+		return nil
+	}
+
+	return json.Unmarshal(choices, &f.Choices)
+}
+
+func (p EmbedJSPage) MarshalJSON() ([]byte, error) {
+	pageHelpLink := any(nil)
+	if len(p.PageHelpLinks) > 0 {
+		pageHelpLink = p.PageHelpLinks
+	} else if p.PageHelpLink != "" {
+		pageHelpLink = p.PageHelpLink
+	}
+
+	return json.Marshal(struct {
+		Code               string            `json:"code,omitempty"`
+		Menu               string            `json:"menu,omitempty"`
+		ParentMenuItemCode string            `json:"parentMenuItemCode,omitempty"`
+		MenuItemOrdering   int               `json:"menuItemOrdering,omitempty"`
+		MenuItemTitle      map[string]string `json:"menuItemTitle,omitempty"`
+		PageHelpLink       any               `json:"pageHelpLink,omitempty"`
+		IsSettingsMainPage bool              `json:"isSettingsMainPage,omitempty"`
+	}{
+		Code:               p.Code,
+		Menu:               p.Menu,
+		ParentMenuItemCode: p.ParentMenuItemCode,
+		MenuItemOrdering:   p.MenuItemOrdering,
+		MenuItemTitle:      p.MenuItemTitle,
+		PageHelpLink:       pageHelpLink,
+		IsSettingsMainPage: p.IsSettingsMainPage,
+	})
+}
+
+func (p *EmbedJSPage) UnmarshalJSON(data []byte) error {
+	var response struct {
+		Code               string            `json:"code"`
+		Menu               string            `json:"menu"`
+		ParentMenuItemCode string            `json:"parentMenuItemCode"`
+		MenuItemOrdering   int               `json:"menuItemOrdering"`
+		MenuItemTitle      map[string]string `json:"menuItemTitle"`
+		PageHelpLink       json.RawMessage   `json:"pageHelpLink"`
+		IsSettingsMainPage bool              `json:"isSettingsMainPage"`
+	}
+
+	if err := json.Unmarshal(data, &response); err != nil {
+		return err
+	}
+
+	p.Code = response.Code
+	p.Menu = response.Menu
+	p.ParentMenuItemCode = response.ParentMenuItemCode
+	p.MenuItemOrdering = response.MenuItemOrdering
+	p.MenuItemTitle = response.MenuItemTitle
+	p.PageHelpLink = ""
+	p.PageHelpLinks = nil
+	p.IsSettingsMainPage = response.IsSettingsMainPage
+
+	pageHelpLink := bytes.TrimSpace(response.PageHelpLink)
+	if len(pageHelpLink) == 0 || bytes.Equal(pageHelpLink, []byte("null")) {
+		return nil
+	}
+
+	if pageHelpLink[0] == '"' {
+		return json.Unmarshal(pageHelpLink, &p.PageHelpLink)
+	}
+
+	var translations ConfigurationTranslation
+	if err := json.Unmarshal(pageHelpLink, &translations); err != nil {
+		return err
+	}
+
+	p.PageHelpLinks = translations
+	p.PageHelpLink = firstTranslation(translations)
+
+	return nil
+}
+
+func firstTranslation(translations ConfigurationTranslation) string {
+	for _, lang := range []string{"ru", "en", "es"} {
+		if value := translations[lang]; value != "" {
+			return value
+		}
+	}
+
+	for _, value := range translations {
+		return value
+	}
+
+	return ""
+}
+
 func (v *StringOrNumber) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		*v = ""
@@ -35,6 +245,71 @@ func (v *StringOrNumber) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+func (r *IntegrationModuleEditResponse) UnmarshalJSON(data []byte) error {
+	var response struct {
+		Success bool            `json:"success"`
+		Info    json.RawMessage `json:"info"`
+	}
+
+	if err := json.Unmarshal(data, &response); err != nil {
+		return err
+	}
+
+	r.Success = response.Success
+	r.Info = ResponseInfo{}
+	r.InfoList = nil
+	r.InfoRaw = nil
+
+	info := bytes.TrimSpace(response.Info)
+	if len(info) == 0 || bytes.Equal(info, []byte("null")) {
+		return nil
+	}
+
+	r.InfoRaw = append(r.InfoRaw, response.Info...)
+
+	switch info[0] {
+	case '[':
+		var infoList []ResponseInfo
+		if err := json.Unmarshal(info, &infoList); err != nil {
+			return err
+		}
+
+		r.InfoList = infoList
+		if len(infoList) > 0 {
+			r.Info = infoList[0]
+		}
+
+		return nil
+	case '{':
+		return json.Unmarshal(info, &r.Info)
+	default:
+		return fmt.Errorf("integration module edit info: expected object or array, got %q", info[0])
+	}
+}
+
+func (r *ResponseInfo) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if bytes.Equal(data, []byte("null")) {
+		*r = ResponseInfo{}
+		return nil
+	}
+
+	if len(data) > 0 && data[0] == '[' {
+		var values []json.RawMessage
+		if err := json.Unmarshal(data, &values); err != nil {
+			return err
+		}
+
+		if len(values) == 0 {
+			*r = ResponseInfo{}
+			return nil
+		}
+	}
+
+	type responseInfo ResponseInfo
+	return json.Unmarshal(data, (*responseInfo)(r))
 }
 
 func (a *APIErrorsList) UnmarshalJSON(data []byte) error {

--- a/marshaling_test.go
+++ b/marshaling_test.go
@@ -50,6 +50,268 @@ func TestStringOrNumber_MarshalJSON(t *testing.T) {
 	assert.JSONEq(t, `{"code":"main","ordering":"10"}`, string(data))
 }
 
+func TestResponseInfo_UnmarshalJSON(t *testing.T) {
+	var fromObject ResponseInfo
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"deliveryType": {
+			"id": 38,
+			"code": "sdek-v-2-podkliuchenie-1"
+		},
+		"billingInfo": {
+			"price": 0,
+			"currency": {
+				"name": "Рубль",
+				"shortName": "руб.",
+				"code": "RUB"
+			},
+			"billingType": "fixed"
+		}
+	}`), &fromObject))
+
+	assert.Equal(t, 38, fromObject.DeliveryTypeInfo.ID)
+	assert.Equal(t, "sdek-v-2-podkliuchenie-1", fromObject.DeliveryTypeInfo.Code)
+	require.NotNil(t, fromObject.BillingInfo)
+	require.NotNil(t, fromObject.BillingInfo.Currency)
+	assert.Equal(t, "RUB", fromObject.BillingInfo.Currency.Code)
+
+	var fromArray ResponseInfo
+	require.NoError(t, json.Unmarshal([]byte(`[]`), &fromArray))
+	assert.Equal(t, ResponseInfo{}, fromArray)
+
+	fromArray = ResponseInfo{
+		BillingInfo: &BillingInfo{BillingType: "fixed"},
+	}
+	require.NoError(t, json.Unmarshal([]byte(`null`), &fromArray))
+	assert.Equal(t, ResponseInfo{}, fromArray)
+}
+
+func TestIntegrationModuleEditResponse_UnmarshalJSON(t *testing.T) {
+	var fromObject IntegrationModuleEditResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"success": true,
+		"info": {
+			"billingInfo": {
+				"billingType": "fixed"
+			}
+		}
+	}`), &fromObject))
+
+	assert.True(t, fromObject.Success)
+	assert.Equal(t, "fixed", fromObject.Info.BillingInfo.BillingType)
+	assert.JSONEq(t, `{"billingInfo":{"billingType":"fixed"}}`, string(fromObject.InfoRaw))
+	assert.Empty(t, fromObject.InfoList)
+
+	var fromEmptyArray IntegrationModuleEditResponse
+	require.NoError(t, json.Unmarshal([]byte(`{"success": true, "info": []}`), &fromEmptyArray))
+
+	assert.True(t, fromEmptyArray.Success)
+	assert.Equal(t, ResponseInfo{}, fromEmptyArray.Info)
+	assert.JSONEq(t, `[]`, string(fromEmptyArray.InfoRaw))
+	assert.Empty(t, fromEmptyArray.InfoList)
+
+	var fromArray IntegrationModuleEditResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"success": true,
+		"info": [
+			{
+				"deliveryType": {
+					"id": 38,
+					"code": "sdek-v-2-podkliuchenie-1"
+				}
+			}
+		]
+	}`), &fromArray))
+
+	require.Len(t, fromArray.InfoList, 1)
+	assert.Equal(t, 38, fromArray.InfoList[0].DeliveryTypeInfo.ID)
+	assert.Equal(t, fromArray.InfoList[0], fromArray.Info)
+}
+
+func TestIntegrationModule_MarshalNewAndLegacyFields(t *testing.T) {
+	active := true
+
+	module := IntegrationModule{
+		Code:               "module-code",
+		IntegrationCode:    "integration-code",
+		Active:             &active,
+		AvailableCountries: []string{"RU"},
+		Integrations: &Integrations{
+			Delivery: &Delivery{
+				DeliveryDataFieldList: []DeliveryDataField{
+					{
+						Code: "terminal",
+						Type: "choice",
+						ChoiceList: []DeliveryDataFieldChoice{
+							{
+								Value: "terminal-1",
+								Label: "Terminal 1",
+							},
+						},
+					},
+				},
+			},
+			Payment: &PaymentModule{
+				Actions:      PaymentModuleActions{Create: "/create"},
+				InvoiceTypes: []string{"link"},
+				Shops: []PaymentModuleShop{
+					{
+						Code:   "main",
+						Name:   "Main shop",
+						Active: true,
+					},
+				},
+			},
+			EmbedJS: &EmbedJS{
+				Pages: []EmbedJSPage{
+					{
+						Code:          "settings",
+						MenuItemTitle: map[string]string{"ru": "Настройки"},
+						PageHelpLinks: ConfigurationTranslation{"ru": "https://example.com/help"},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(module)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"code": "module-code",
+		"integrationCode": "integration-code",
+		"active": true,
+		"availableCountries": ["RU"],
+		"integrations": {
+			"delivery": {
+				"deliveryDataFieldList": [
+					{
+						"code": "terminal",
+						"type": "choice",
+						"choices": [
+							{
+								"value": "terminal-1",
+								"label": "Terminal 1"
+							}
+						]
+					}
+				]
+			},
+			"payment": {
+				"actions": {
+					"create": "/create"
+				},
+				"invoiceTypes": ["link"],
+				"shops": [
+					{
+						"code": "main",
+						"name": "Main shop",
+						"active": true
+					}
+				]
+			},
+			"embedJs": {
+				"pages": [
+					{
+						"code": "settings",
+						"menuItemTitle": {
+							"ru": "Настройки"
+						},
+						"pageHelpLink": {
+							"ru": "https://example.com/help"
+						}
+					}
+				]
+			}
+		}
+	}`, string(data))
+
+	var decoded IntegrationModule
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Integrations)
+	require.NotNil(t, decoded.Integrations.Delivery)
+	require.NotNil(t, decoded.Integrations.EmbedJS)
+
+	deliveryField := decoded.Integrations.Delivery.DeliveryDataFieldList[0]
+	assert.Equal(t, []string{"terminal-1"}, deliveryField.Choices)
+	require.Len(t, deliveryField.ChoiceList, 1)
+	assert.Equal(t, "Terminal 1", deliveryField.ChoiceList[0].Label)
+
+	page := decoded.Integrations.EmbedJS.Pages[0]
+	assert.Equal(t, "https://example.com/help", page.PageHelpLink)
+	assert.Equal(t, ConfigurationTranslation{"ru": "https://example.com/help"}, page.PageHelpLinks)
+
+	legacy := IntegrationModule{
+		Integrations: &Integrations{
+			Telephony: &Telephony{
+				AdditionalCodes: []AdditionalCode{
+					{
+						UserID: "10",
+						Code:   "101",
+					},
+				},
+			},
+			Delivery: &Delivery{
+				DeliveryDataFieldList: []DeliveryDataField{
+					{
+						Code:    "terminal",
+						Choices: []string{"terminal-1"},
+					},
+				},
+			},
+			EmbedJS: &EmbedJS{
+				Pages: []EmbedJSPage{
+					{
+						Code:          "settings",
+						MenuItemTitle: map[string]string{"ru": "Настройки"},
+						PageHelpLink:  "https://example.com/help",
+					},
+				},
+			},
+		},
+	}
+
+	data, err = json.Marshal(legacy)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"integrations": {
+			"telephony": {
+				"additionalCodes": [
+					{
+						"userId": "10",
+						"code": "101"
+					}
+				]
+			},
+			"delivery": {
+				"deliveryDataFieldList": [
+					{
+						"code": "terminal",
+						"choices": ["terminal-1"]
+					}
+				]
+			},
+			"embedJs": {
+				"pages": [
+					{
+						"code": "settings",
+						"menuItemTitle": {
+							"ru": "Настройки"
+						},
+						"pageHelpLink": "https://example.com/help"
+					}
+				]
+			}
+		}
+	}`, string(data))
+}
+
+func TestAdditionalCode_UnmarshalUserIDNumber(t *testing.T) {
+	var additionalCode AdditionalCode
+
+	require.NoError(t, json.Unmarshal([]byte(`{"userId":10,"code":"101"}`), &additionalCode))
+	assert.Equal(t, "10", additionalCode.UserID)
+	assert.Equal(t, "101", additionalCode.Code)
+}
+
 func TestStoreOrdering_UnmarshalStringOrNumber(t *testing.T) {
 	var fromString Store
 	require.NoError(t, json.Unmarshal([]byte(`{"ordering":"10"}`), &fromString))

--- a/response.go
+++ b/response.go
@@ -472,8 +472,10 @@ type UpdateScopesResponse struct {
 
 // IntegrationModuleEditResponse type.
 type IntegrationModuleEditResponse struct {
-	Success bool         `json:"success"`
-	Info    ResponseInfo `json:"info,omitempty"`
+	Success  bool           `json:"success"`
+	Info     ResponseInfo   `json:"info,omitempty"`
+	InfoList []ResponseInfo `json:"-"`
+	InfoRaw  []byte         `json:"-"`
 }
 
 // PaymentCheckResponse type.

--- a/types.go
+++ b/types.go
@@ -391,6 +391,7 @@ type OrderPayments map[string]OrderPayment
 type StringMap map[string]string
 type CustomFieldMap map[string]interface{}
 type Properties map[string]Property
+type ConfigurationTranslation map[string]string
 
 // Order type.
 type Order struct {
@@ -1651,17 +1652,24 @@ type Plate struct {
 
 // DeliveryDataField type.
 type DeliveryDataField struct {
-	Code            string   `json:"code,omitempty"`
-	Label           string   `json:"label,omitempty"`
-	Hint            string   `json:"hint,omitempty"`
-	Type            string   `json:"type,omitempty"`
-	AutocompleteURL string   `json:"autocompleteUrl,omitempty"`
-	Multiple        bool     `json:"multiple,omitempty"`
-	Choices         []string `json:"choices,omitempty"`
-	Visible         bool     `json:"visible,omitempty"`
-	Required        bool     `json:"required,omitempty"`
-	AffectsCost     bool     `json:"affectsCost,omitempty"`
-	Editable        bool     `json:"editable,omitempty"`
+	Code            string                    `json:"code,omitempty"`
+	Label           string                    `json:"label,omitempty"`
+	Hint            string                    `json:"hint,omitempty"`
+	Type            string                    `json:"type,omitempty"`
+	AutocompleteURL string                    `json:"autocompleteUrl,omitempty"`
+	Multiple        bool                      `json:"multiple,omitempty"`
+	Choices         []string                  `json:"choices,omitempty"`
+	ChoiceList      []DeliveryDataFieldChoice `json:"-"`
+	Visible         bool                      `json:"visible,omitempty"`
+	Required        bool                      `json:"required,omitempty"`
+	AffectsCost     bool                      `json:"affectsCost,omitempty"`
+	Editable        bool                      `json:"editable,omitempty"`
+}
+
+// DeliveryDataFieldChoice type.
+type DeliveryDataFieldChoice struct {
+	Value string `json:"value,omitempty"`
+	Label string `json:"label,omitempty"`
 }
 
 // DeliverySettings type.
@@ -1744,13 +1752,14 @@ type EmbedJS struct {
 
 // EmbedJSPage type.
 type EmbedJSPage struct {
-	Code               string            `json:"code,omitempty"`
-	Menu               string            `json:"menu,omitempty"`
-	ParentMenuItemCode string            `json:"parentMenuItemCode,omitempty"`
-	MenuItemOrdering   int               `json:"menuItemOrdering,omitempty"`
-	MenuItemTitle      map[string]string `json:"menuItemTitle,omitempty"`
-	PageHelpLink       string            `json:"pageHelpLink,omitempty"`
-	IsSettingsMainPage bool              `json:"isSettingsMainPage,omitempty"`
+	Code               string                   `json:"code,omitempty"`
+	Menu               string                   `json:"menu,omitempty"`
+	ParentMenuItemCode string                   `json:"parentMenuItemCode,omitempty"`
+	MenuItemOrdering   int                      `json:"menuItemOrdering,omitempty"`
+	MenuItemTitle      map[string]string        `json:"menuItemTitle,omitempty"`
+	PageHelpLink       string                   `json:"pageHelpLink,omitempty"`
+	PageHelpLinks      ConfigurationTranslation `json:"-"`
+	IsSettingsMainPage bool                     `json:"isSettingsMainPage,omitempty"`
 }
 
 // Telephony type.


### PR DESCRIPTION
What changed and why: updated IntegrationModuleEdit request and response DTOs to match the current POST /api/v5/integration-modules/{code}/edit contract. The endpoint can return info as an array, including an empty [], while the client previously expected a ResponseInfo object and failed during json.Unmarshal.

Added custom UnmarshalJSON handling for IntegrationModuleEditResponse and ResponseInfo. The legacy object format still fills Info, array-form info is preserved in InfoRaw/InfoList, and an empty [] is treated as missing additional information. Request DTOs now also support the newer documented shapes: object deliveryDataFieldList[].choices via ChoiceList/DeliveryDataFieldChoice and translated embedJs.pages[].pageHelpLink via PageHelpLinks/ConfigurationTranslation.

Backward compatibility: existing public fields Info, AdditionalCode.UserID, DeliveryDataField.Choices, and EmbedJSPage.PageHelpLink are preserved. During marshaling, new fields take precedence when set, but the old format is still used when they are empty. During unmarshaling, newer formats also populate legacy fields where possible: ChoiceList also fills Choices, numeric AdditionalCode userId fills UserID as a string, and translated pageHelpLink fills PageHelpLink with the first available translation.